### PR TITLE
add space in cd command

### DIFF
--- a/linux/run.sh
+++ b/linux/run.sh
@@ -1,2 +1,2 @@
-cd..
+cd ..
 python3 fcconverter.py


### PR DESCRIPTION
@wizerdspell2007 : I ran into one problem with the linux shell script -- it needed a space between `cd` and `..`.

This pull request has the changes needed to fix that.

Otherwise, looks good to me: 👍